### PR TITLE
drop custom `permissions` param

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- drop the `permissions` argument to `api_view` and leave permissions management to drf's `@permission_classes` decorator
 - use custom exceptions instead of `TypeError` and `assert`s
 
 ## [0.2.0] - 2021-06-29

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ easy-to-use apis and openapi schemas.
     class MyResponse:
         length: int
 
-    @speccify.api_view(methods=["GET"], permissions=[])
+    @speccify.api_view(methods=["GET"])
     def my_view(request: Request, my_query: Query[MyQueryData]) -> MyResponse:
         name = my_query.name
         length = len(name)

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -7,10 +7,7 @@ from tests.helpers import get_schema
 
 
 def test_basic(rf):
-    @api_view(
-        methods=["GET"],
-        permissions=[],
-    )
+    @api_view(methods=["GET"])
     def speccify_view(request: Request) -> None:
         pass  # pragma: no cover
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -11,7 +11,7 @@ class MyInfo:
     val: str
 
 
-@api_view(methods=["GET"], permissions=[])
+@api_view(methods=["GET"])
 def view_get(request: Request, query: Query[MyInfo]) -> None:
     pass  # pragma: no cover
 


### PR DESCRIPTION
drop the `permissions` argument to `api_view` and leave permissions
management to drf's `@permission_classes` decorator